### PR TITLE
Create a docker-compose playground to test the config

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,10 @@ This configuration requires the following packages installed via package manager
 * tree
 * [Git.Git](https://winget.run/pkg/Git/Git) (in the Windows host)
 
+## Playground
+
+This repository can be cloned to a separate directory and the configuration tested in a docker container by using the docker-compose stack in the `_tests` directory.
+
 ## GIT Configuration
 
 The setup of these is beyond the scope of this documentation and can be replaced by other mechanisms.

--- a/_tests/Dockerfile
+++ b/_tests/Dockerfile
@@ -1,0 +1,55 @@
+FROM ubuntu:latest
+
+ARG USERNAME=zshtester
+ARG USERPASS=Pass1234
+
+ARG LOCALE_INPUT=en_US
+ARG LOCALE_CHARMAP=UTF-8
+
+ARG TZ=America/Argentina/Buenos_Aires
+
+RUN apt update \
+  && DEBIAN_FRONTEND="noninteractive" apt upgrade -y \
+  && ln -fs /usr/share/zoneinfo/${TZ} /etc/localtime \
+  && DEBIAN_FRONTEND="noninteractive" apt install -y \
+    autoconf \
+    automake \
+    bsdextrautils \
+    curl \
+    file \
+    gcc \
+    git \
+    locales \
+    make \
+    sudo \
+    tree \
+    tzdata \
+    unzip \
+    vim \
+    zsh \
+  && rm -rf /var/lib/apt/lists/* \
+  && dpkg-reconfigure --frontend noninteractive tzdata \
+	&& localedef -i ${LOCALE_INPUT} -c -f ${LOCALE_CHARMAP} -A /usr/share/locale/locale.alias ${LOCALE_INPUT}.${LOCALE_CHARMAP}
+
+ADD ./files/docker-entrypoint.sh /docker-entrypoint.sh
+
+RUN chmod +x /docker-entrypoint.sh \
+  && useradd --shell /usr/bin/zsh -c "ZSH testing user" -m -U -G sudo -p $(openssl passwd -6 -salt xyz ${USERPASS}) ${USERNAME} \
+  && mkdir -p /home/${USERNAME}/.config/zsh \
+  && chown -R ${USERNAME} /home/${USERNAME}/.config
+
+USER ${USERNAME}
+WORKDIR /home/${USERNAME}
+
+VOLUME [ \
+          "/home/${USERNAME}/.config/zsh/.zshenv", \
+          "/home/${USERNAME}/.config/zsh/.zshrc", \
+          "/home/${USERNAME}/.config/zsh/zshrc.d", \
+          "/home/${USERNAME}/.config/zsh/files.d", \
+          "/home/${USERNAME}/.config/zsh/functions.d", \
+          "/home/${USERNAME}/.config/zsh/aliases.d", \
+]
+
+RUN ln -s .config/zsh/.zshenv .zshenv
+
+ENTRYPOINT ["bash", "/docker-entrypoint.sh"]

--- a/_tests/README.md
+++ b/_tests/README.md
@@ -1,0 +1,32 @@
+# ZSH configuration testing grounds
+
+## Requirements
+
+This configuration requires:
+* [Just](https://just.systems/) command runner
+* Docker
+* Docker Compose (usually included with Docker)
+* Internet access
+
+## The Stack
+
+A base image is built on top of `ubuntu:latest`, installing required packages and setting up the desired locale, creating a test user and mounting the configurations as read-only files and directories.
+The name and password of the user, as well as the locale to create can be overriden.
+
+## Caveats
+
+Only some files and directories are mounted and anything created by the configuration is only present within the container and will not be persisted.
+Mounted files are read-only and can't be modified from within the container.
+
+## Usage
+
+### Building, Starting and Stopping
+
+`Just` may be used to run these commands simply by executing `just` with no parameters for command selector or `just --list` to get a list.
+
+To start the container, running `docker compose up -d --build` will build a new image if necessary, and start a service called `zshtest`.
+Once the tests have been completed, `docker compose down` can be executed to destroy the container or `docker compose stop` to just stop it.
+
+### Connecting to the container
+
+To start a session in the container and apply the Zsh configuration run `docker compose exec zshtest /usr/bin/zsh`.

--- a/_tests/docker-compose.yml
+++ b/_tests/docker-compose.yml
@@ -1,0 +1,20 @@
+---
+services:
+  zshtest:
+    build:
+      context: .
+      args:
+        - USERNAME=zshtester
+        - USERPASS=Pass1234
+        - LOCALE_INPUT=en_US
+        - LOCALE_CHARMAP=UTF-8
+        - TZ=America/Argentina/Buenos_Aires
+    working_dir: /home/zshtester
+    volumes:
+      - ../.zshenv:/home/zshtester/.config/zsh/.zshenv:ro
+      - ../.zshrc:/home/zshtester/.config/zsh/.zshrc:ro
+      - ../aliases.d:/home/zshtester/.config/zsh/aliases.d:ro
+      - ../files.d:/home/zshtester/.config/zsh/files.d:ro
+      - ../functions.d:/home/zshtester/.config/zsh/functions.d:ro
+      - ../zshrc.d:/home/zshtester/.config/zsh/zshrc.d:ro
+

--- a/_tests/files/docker-entrypoint.sh
+++ b/_tests/files/docker-entrypoint.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+if [[ ! -z ${USE_PROXY:-''} ]]; then
+  git config --global http.proxy ${USE_PROXY:-''}
+  git config --global http.sslVerify false
+fi
+
+echo "Your playground is ready"
+echo "Connect to the container's terminal and execute zsh"
+
+sleep infinity


### PR DESCRIPTION
Within the `_tests` directory there is a docker-compose stack that will allow testing most of the configuration.
